### PR TITLE
Remove 2nd instance of HotModuleReplacementPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,6 @@ module.exports = {
 	},
 	mode,
 	plugins: [
-		!prod && new webpack.HotModuleReplacementPlugin(),
 		new MiniCssExtractPlugin({
 			filename: '[name].css'
 		})


### PR DESCRIPTION
`webpack-serve` uses `webpack-hot-client` which [already includes the HotModuleReplacementPlugin](https://github.com/webpack-contrib/webpack-hot-client#gotchas). 

This fixes the stack overflow with `webpackHotUpdateCallback`.