### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,20 @@
   "name": "svelte-app",
   "version": "1.0.0",
   "devDependencies": {
-    "cross-env": "^5.1.5",
-    "css-loader": "^0.28.11",
-    "mini-css-extract-plugin": "^0.4.0",
-    "serve": "^6.5.5",
+    "cross-env": "^5.2.0",
+    "css-loader": "^1.0.0",
+    "mini-css-extract-plugin": "^0.4.1",
+    "serve": "^9.2.0",
     "style-loader": "^0.21.0",
-    "svelte": "^2.0.0",
-    "svelte-loader": "2.9.0",
-    "webpack": "^4.8.3",
-    "webpack-cli": "^2.0.14",
-    "webpack-serve": "^1.0.2"
+    "svelte": "^2.9.3",
+    "svelte-loader": "^2.9.1",
+    "webpack": "^4.15.1",
+    "webpack-cli": "^3.0.8",
+    "webpack-serve": "^2.0.2"
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
-    "dev": "webpack-serve --content public --hot"
-  }
+    "dev": "webpack-serve --content public --hmr"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Right now, the hot reload is not working with the actual deps, and svelte loader 2.9.0 has an error with windows 10 paths 

see https://github.com/sveltejs/svelte-loader/pull/64