### PR TITLE
svelte-loader updated to 2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "serve": "^6.5.5",
     "style-loader": "^0.21.0",
     "svelte": "^2.0.0",
-    "svelte-loader": "2.9.0",
+    "svelte-loader": "2.11.0",
     "webpack": "^4.8.3",
     "webpack-cli": "^2.0.14",
     "webpack-serve": "^1.0.2"


### PR DESCRIPTION
Because 2.9.0 version was causing a crush on startup on Windows