### PR TITLE
Css loader update

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,11 +35,7 @@ module.exports = {
 			{
 				test: /\.css$/,
 				use: [
-					/**
-					 * MiniCssExtractPlugin doesn't support HMR.
-					 * For developing, use 'style-loader' instead.
-					 * */
-					prod ? MiniCssExtractPlugin.loader : 'style-loader',
+					MiniCssExtractPlugin.loader,
 					'css-loader'
 				]
 			}


### PR DESCRIPTION
MiniCssExtractPlugin now supports HMR, as of April 10, 2019.
Their loader now works in development.