### PR TITLE
mock node fs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,5 +51,8 @@ module.exports = {
 			filename: '[name].css'
 		})
 	],
-	devtool: prod ? false: 'source-map'
+	devtool: prod ? false: 'source-map',
+	node: {
+	  fs: 'empty'
+	}
 };


### PR DESCRIPTION
this allows for external dependencies that were written for node to be bundled properly

[link](https://webpack.js.org/configuration/node/)