### PR TITLE
fix: set alias correctly

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
 	},
 	resolve: {
 		alias: {
-			svelte: path.resolve('node_modules', 'svelte')
+			svelte: path.dirname(require.resolve('svelte/package.json'))
 		},
 		extensions: ['.mjs', '.js', '.svelte'],
 		mainFields: ['svelte', 'browser', 'module', 'main']


### PR DESCRIPTION
**What's the problem this PR addresses?**

The current `svelte` alias assumes `node_modules/svelte` exists but this is not guaranteed in monorepos

**How did you fix it?**

Use `require.resolve` to locate `svelte`