### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
 node_modules
 public/bundle.*
-package-lock.json
-yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 node_modules
-public/bundle.*
+public/build/bundle.*


### PR DESCRIPTION
## Remove lock file gitignores
Reasons: 
- "Do I commit the package-lock.json file created by npm 5?" (https://stackoverflow.com/questions/39990017/should-i-commit-the-yarn-lock-file-and-what-is-it-for) and
- "Should I commit the yarn.lock file?" (https://stackoverflow.com/questions/39990017/should-i-commit-the-yarn-lock-file-and-what-is-it-for)
- The svelte rollup template does not have these files in the gitignore. https://github.com/sveltejs/template/blob/master/.gitignore

## Fix gitignore build path
Reasons:
- It was changed with https://github.com/sveltejs/template-webpack/issues/34 and https://github.com/sveltejs/template-webpack/pull/36 but the gitignore was forgotten.