### PR TITLE
Add Typescript instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ npm run dev
 Navigate to [localhost:8080](http://localhost:8080). You should see your app running. Edit a component file in `src`, save it, and the page should reload with your changes.
 
 
+## Using TypeScript
+
+This template comes with a script to set up a TypeScript development environment, you can run it immediately after cloning the template with:
+
+```bash
+node scripts/setupTypeScript.js
+```
+
+Or remove the script via:
+
+```bash
+rm scripts/setupTypeScript.js
+```
+
 ## Deploying to the web
 
 ### With [now](https://zeit.co/now)


### PR DESCRIPTION
Copied over from: https://github.com/sveltejs/template/blob/master/README.md

The instructions seem to be the same