### PR TITLE
[fix] historyApiFallback on webpack-dev-server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = {
 	],
 	devtool: prod ? false : 'source-map',
 	devServer: {
-		hot: true
+		hot: true,
+		historyApiFallback: true,
 	}
 };


### PR DESCRIPTION
This PR will fix #49 by adding `historyApiFallback` to webpack-dev-server, [Official webpack docs about this property](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback).

This attribute only works on dev-server, so it has no impact on the production build.