### PR TITLE
Upgraded dependencies and changed deprecated API's

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
   "version": "1.0.0",
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "css-loader": "^5.0.1",
-    "mini-css-extract-plugin": "^1.3.4",
-    "svelte": "^3.31.2",
-    "svelte-loader": "^3.0.0",
-    "webpack": "^5.16.0",
-    "webpack-cli": "^4.4.0",
-    "webpack-dev-server": "^3.11.2"
+    "css-loader": "^6.7.1",
+    "mini-css-extract-plugin": "^2.6.0",
+    "svelte": "^3.46.4",
+    "svelte-loader": "^3.1.2",
+    "webpack": "^5.70.0",
+    "webpack-cli": "^4.9.2",
+    "webpack-dev-server": "^4.7.4"
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
-    "dev": "webpack serve --content-base public"
+    "dev": "webpack serve"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,9 @@ module.exports = {
 	],
 	devtool: prod ? false : 'source-map',
 	devServer: {
-		hot: true
+		hot: true,
+		static: {
+			directory: path.join(__dirname, 'public'),
+		}
 	}
 };


### PR DESCRIPTION
```
 css-loader                ^5.0.1  ->   ^6.7.1
 mini-css-extract-plugin   ^1.3.4  ->   ^2.6.0
 svelte                   ^3.31.2  ->  ^3.46.4
 svelte-loader             ^3.0.0  ->   ^3.1.2
 webpack                  ^5.16.0  ->  ^5.70.0
 webpack-cli               ^4.4.0  ->   ^4.9.2
 webpack-dev-server       ^3.11.2  ->   ^4.7.4
```

I moved `--content-base` to the WebPack config, as it's deprecated and removed.